### PR TITLE
Actually disable CoW on @swap and @var_log

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -76,6 +76,9 @@ mount -o nodatacow,subvol=@swap $BTRFS /mnt/swap
 mkdir /mnt/boot/efi
 mount $ESP /mnt/boot/efi
 
+chattr +C @/mnt/var/log
+chattr +C @/mnt/swap
+
 # Pacstrap (setting up a base sytem onto the new root).
 echo "Installing the base system (it may take a while)."
 pacstrap /mnt base linux linux-firmware btrfs-progs grub grub-btrfs efibootmgr snapper sudo networkmanager


### PR DESCRIPTION
There is a bug with BTRFS where it uses the same mount option for the first subvolume for any subvolumes you mount. That means the nodatacow flag you set on line 74 and 75 are useless. In order to disable CoW, you must add chattr +C to those.

https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs(5)