### PR TITLE
FEATURE: Adds option to install the base-devel package group

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -146,6 +146,19 @@ pacstrap /mnt base $kernel $microcode linux-firmware btrfs-progs grub grub-btrfs
 
 network_selector
 
+# Choice to install base-devel package
+echo "base-devel contains helpful tools like gcc, automake, autoconf, sudo and many others."
+read -r -p "This will install the base-devel package. Do you agree [y/N]? " bd_response
+bd_response=${bd_response,,}
+if [[ "$bd_response" =~ ^(yes|y)$ ]]
+then
+    echo "Installing the package.."
+    pacstrap /mnt base-devel
+else
+    echo "Quitting."
+    exit
+fi
+
 # Generating /etc/fstab.
 echo "Generating a new fstab."
 genfstab -U /mnt >> /mnt/etc/fstab


### PR DESCRIPTION
**Description:**
Adds a prompt asking the user if they want to install the base-devel package or not.
This happens after installation of network packages. Default option is `no.`

**Benefits:**
This package includes many tools like automake, gcc, and autoconf that are useful when compiling/making cloned packages or repositories. It also comes with sudo and other tools as well.
Full list can be found [here](https://archlinux.org/groups/x86_64/base-devel/)