### PR TITLE
Enable grub-btrfs.path

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -214,6 +214,7 @@ arch-chroot /mnt /bin/bash -e <<EOF
     mkdir /.snapshots
     mount -a
     chmod 750 /.snapshots
+    systemctl enable grub-btrfs.path
 
     # Installing GRUB.
     echo "Installing GRUB on /boot."


### PR DESCRIPTION
This is needed for automatically detecting new snapshots and adding them to GRUB