### PR TITLE
Fixed typo in btrfs subvolume mounting 

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -132,7 +132,7 @@ umount /mnt
 echo "Mounting the newly created subvolumes."
 mount -o ssd,noatime,space_cache,compress=zstd,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,.snapshots,/var/log,boot}
-mount -o ssd,noatime,space_cache.compress=zstd,autodefrag,discard=async,subvol=@home $BTRFS /mnt/home
+mount -o ssd,noatime,space_cache,compress=zstd,autodefrag,discard=async,subvol=@home $BTRFS /mnt/home
 mount -o ssd,noatime,space_cache,compress=zstd,autodefrag,discard=async,subvol=@snapshots $BTRFS /mnt/.snapshots
 mount -o ssd,noatime,space_cache,compress=zstd,autodefrag,discard=async,subvol=@var_log $BTRFS /mnt/var/log
 chattr +C /mnt/var/log


### PR DESCRIPTION
When mounting a btrfs subvolume, there was a period instead of a comma.