### PR TITLE
Add linux-headers package to installation

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -239,7 +239,7 @@ network_selector
 
 # Pacstrap (setting up a base sytem onto the new root).
 print "Installing the base system (it may take a while)."
-pacstrap /mnt base $kernel $microcode linux-firmware linux-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector base-devel snap-pac zram-generator
+pacstrap /mnt base $kernel $microcode linux-firmware $kernel-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector base-devel snap-pac zram-generator
 
 # Setting up the hostname.
 hostname_selector

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -239,7 +239,7 @@ network_selector
 
 # Pacstrap (setting up a base sytem onto the new root).
 print "Installing the base system (it may take a while)."
-pacstrap /mnt base $kernel $microcode linux-firmware btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector base-devel snap-pac zram-generator
+pacstrap /mnt base $kernel $microcode linux-firmware linux-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector base-devel snap-pac zram-generator
 
 # Setting up the hostname.
 hostname_selector


### PR DESCRIPTION
Add `linux-headers` package, which is helpful to get tools like drawing tablets to work. 
(ref: https://archlinux.org/packages/core/x86_64/linux-headers/)