### PR TITLE
Update zRAM config

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -404,8 +404,7 @@ EOF
 print "Configuring ZRAM."
 cat > /mnt/etc/systemd/zram-generator.conf <<EOF
 [zram0]
-zram-fraction = 1
-max-zram-size = 8192
+zram-size = min(ram, 8192)
 EOF
 
 # Pacman eye-candy features.


### PR DESCRIPTION
as noted in [manpage](https://man.archlinux.org/man/zram-generator.conf.5) both options are obsolete.