### PR TITLE
Inprovements

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -89,6 +89,7 @@ network_selector () {
         incEcho "You did not enter a valid selection."
         return 1
     fi
+    return 0
 }
 
 # Installing the chosen networking method to the system (function).
@@ -131,7 +132,7 @@ lukspass_selector () {
         incEcho "Passwords don't match, try again."
         return 1
     fi
-	return 0
+    return 0
 }
 
 # User enters a password for the user account (function).
@@ -148,7 +149,7 @@ userpass_selector () {
         incEcho "Passwords don't match, try again."
         return 1
     fi
-	return 0
+    return 0
 }
 
 # User enters a password for the root account (function).
@@ -165,7 +166,7 @@ rootpass_selector () {
         incEcho "Passwords don't match, try again."
         return 1
     fi
-	return 0
+    return 0
 }
 
 # Microcode detector (function).
@@ -194,8 +195,9 @@ hostname_selector () {
 locale_selector () {
     read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or \"/\" to search locales): " locale
     case $locale in
-        '') print "en_US.UTF-8 will be the default locale."
-            locale="en_US.UTF-8";;
+        '') locale="en_US.UTF-8"
+            print "$locale will be the default locale."
+            return 0;;
         '/') sed -E '/^# +|^#$/d;s/^#| *$//g;s/ .*/      (Charset:&)/' /etc/locale.gen | less -M
              clear
              return 1;;
@@ -211,8 +213,8 @@ locale_selector () {
 keyboard_selector () {
     read -r -p "Please insert the keyboard keymap/layout to use in console (enter empty to use us, or \"/\" to search keymaps): " kblayout
     case $kblayout in
-        '') print "The us keymap will be used in console by default."
-            kblayout="us"
+        '') kblayout="us"
+            print "$kblayout will be the default console keymap."
             return 0;;
         '/') localectl list-keymaps
              clear
@@ -245,8 +247,7 @@ done
 # Warn user about deletion of old partition scheme.
 echo -en "${BOLD}${BRED}This will delete the current partition table on $DISK once installation starts. Do you agree [y/N]?:${RESET} "
 read -r disk_response
-disk_response=${disk_response,,}
-if ! [[ "$disk_response" =~ ^(yes|y)$ ]]; then
+if ! [[ "${disk_response,,}" =~ ^(yes|y)$ ]]; then
     print "Quitting."
     exit
 fi

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -254,9 +254,9 @@ mount $BTRFS /mnt
 
 # Creating BTRFS subvolumes.
 print "Creating BTRFS subvolumes."
-for volume in @ @home @root @srv @snapshots @var_log @var_pkgs
-do
-    btrfs su cr /mnt/$volume
+subvols=(snapshots var_pkgs var_log home root srv)
+for subvol in '' ${subvols[@]}; do
+    btrfs su cr /mnt/@$volume
 done
 
 # Mounting the newly created subvolumes.
@@ -264,11 +264,10 @@ umount /mnt
 print "Mounting the newly created subvolumes."
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,/var/log,/var/cache/pacman/pkg,boot}
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@home $BTRFS /mnt/home
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@root $BTRFS /mnt/root
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@srv $BTRFS /mnt/srv
+for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@var_pkgs and @snapshots) from loop
+mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
+done
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@snapshots $BTRFS /mnt/.snapshots
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@var_log $BTRFS /mnt/var/log
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log
 mount $ESP /mnt/boot/

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -119,56 +119,53 @@ network_installer () {
 
 # User enters a password for the LUKS Container (function).
 lukspass_selector () {
-    while true; do
-        read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
-        while [ -z "$password" ]; do
-            echo
-            incEcho "You need to enter a password for the LUKS Container in order to continue."
-            read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
-            [ -n "$password" ] && break
-        done
-        echo
-        read -r -s -p "Password (again): " password2
-        echo
-        [ "$password" = "$password2" ] && break
+    read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
+    if [ -z "$password" ]; then
+        incEcho "\nYou need to enter a password for the LUKS Container in order to continue."
+        return 1
+    fi
+    echo
+    read -r -s -p "Password (again): " password2
+    echo
+    if [ "$password" != "$password2" ]; then
         incEcho "Passwords don't match, try again."
-    done
+        return 1
+    fi
+	return 0
 }
 
 # User enters a password for the user account (function).
 userpass_selector () {
-    while true; do
-        read -r -s -p "Set a user password for $username: " userpass
-        while [ -z "$userpass" ]; do
-            echo
-            incEcho "You need to enter a password for $username."
-            read -r -s -p "Set a user password for $username: " userpass
-            [ -n "$userpass" ] && break
-        done
-        echo
-        read -r -s -p "Insert password again: " userpass2
-        echo
-        [ "$userpass" = "$userpass2" ] && break
+    read -r -s -p "Set a user password for $username: " userpass
+    if [ -z "$userpass" ]; then
+        incEcho "\nYou need to enter a password for $username."
+        return 1
+    fi
+    echo
+    read -r -s -p "Insert password again: " userpass2
+    echo
+    if [ "$userpass" != "$userpass2" ]; then
         incEcho "Passwords don't match, try again."
-    done
+        return 1
+    fi
+	return 0
 }
 
 # User enters a password for the root account (function).
 rootpass_selector () {
-    while true; do
-        read -r -s -p "Set a root password: " rootpass
-        while [ -z "$rootpass" ]; do
-            echo
-            incEcho "You need to enter a root password."
-            read -r -s -p "Set a root password: " rootpass
-            [ -n "$rootpass" ] && break
-        done
-        echo
-        read -r -s -p "Password (again): " rootpass2
-        echo
-        [ "$rootpass" = "$rootpass2" ] && break
+    read -r -s -p "Set a root password: " rootpass
+    if [ -z "$rootpass" ]; then
+        incEcho "\nYou need to enter a root password."
+        return 1
+    fi
+    echo
+    read -r -s -p "Password (again): " rootpass2
+    echo
+    if [ "$rootpass" != "$rootpass2" ]; then
         incEcho "Passwords don't match, try again."
-    done
+        return 1
+    fi
+	return 0
 }
 
 # Microcode detector (function).
@@ -197,7 +194,7 @@ hostname_selector () {
 locale_selector () {
     read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or \"/\" to search locales): " locale
     case $locale in
-        '') print "en_US will be used as default locale."
+        '') print "en_US.UTF-8 will be the default locale."
             locale="en_US.UTF-8";;
         '/') sed -E '/^# +|^#$/d;s/^#| *$//g;s/ .*/      (Charset:&)/' /etc/locale.gen | less -M
              clear
@@ -255,7 +252,7 @@ if ! [[ "$disk_response" =~ ^(yes|y)$ ]]; then
 fi
 
 # Setting up LUKS password.
-lukspass_selector
+until lukspass_selector; do : ; done
 
 # Setting up the kernel.
 until kernel_selector; do : ; done
@@ -271,8 +268,8 @@ until hostname_selector; do : ; done
 
 # User chooses username.
 read -r -p "Please enter name for a user account (enter empty to not create one): " username
-userpass_selector
-rootpass_selector
+until userpass_selector; do : ; done
+until rootpass_selector; do : ; done
 
 # Deleting old partition scheme.
 print "Wiping $DISK."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -203,7 +203,7 @@ locale_selector () {
         '/') sed -E '/^# +|^#$/d;s/^#| *$//g;s/ .*/      (Charset:&)/' /etc/locale.gen | less -M
              clear
              return 1;;
-        *) if ! grep -Fxq $locale /etc/locale.gen; then
+        *) if ! grep -q "^#\?$(sed 's/[].*[]/\\&/g' <<< $locale) " /etc/locale.gen; then
                incEcho "The specified locale doesn't exist or isn't supported."
                return 1
            fi

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -262,13 +262,14 @@ done
 # Mounting the newly created subvolumes.
 umount /mnt
 print "Mounting the newly created subvolumes."
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@ $BTRFS /mnt
+mountopts="ssd,noatime,compress-force=zstd:3,discard=async"
+mount -o $mountopts,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
+mount -o $mountopts,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
 done
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@snapshots $BTRFS /mnt/.snapshots
-mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
+mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots
+mount -o $mountopts,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log
 mount $ESP /mnt/boot/
 

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -8,7 +8,7 @@ clear
   UNDERLINE='\e[4m'
   RESET='\e[0m' # Reset text to default appearance
 #   High intensity colors:
-	BRED='\e[91m'
+    BRED='\e[91m'
     BGREEN='\e[92m'
     BYELLOW='\e[93m'
     BPURPLE='\e[95m'
@@ -57,7 +57,7 @@ virt_check () {
     esac
 }
 
-# Selecting a kernel to install (function). 
+# Selecting a kernel to install (function).
 kernel_selector () {
     print "List of kernels:"
     print "1) Stable: Vanilla Linux kernel with a few specific Arch Linux patches applied"
@@ -79,7 +79,7 @@ kernel_selector () {
     esac
 }
 
-# Selecting a way to handle internet connection (function). 
+# Selecting a way to handle internet connection (function).
 network_selector () {
     print "Network utilities:"
     print "1) IWD: iNet wireless daemon is a wireless daemon for Linux written by Intel (WiFi-only)"
@@ -232,7 +232,7 @@ keyboard_selector () {
            loadkeys $kblayout
            return 0
     esac
-    
+
 }
 
 # Selecting the target for the installation.
@@ -378,25 +378,25 @@ print "Setting up grub config."
 UUID=$(blkid -s UUID -o value $CRYPTROOT)
 sed -i "s,^GRUB_CMDLINE_LINUX=\",&rd.luks.name=$UUID=cryptroot root=$BTRFS\",g" /mnt/etc/default/grub
 
-# Configuring the system.    
+# Configuring the system.
 arch-chroot /mnt /bin/bash -e <<EOF
 
     # Setting up timezone.
     echo "Setting up the timezone."
     ln -sf /usr/share/zoneinfo/$(curl -s http://ip-api.com/line?fields=timezone) /etc/localtime &>/dev/null
-    
+
     # Setting up clock.
     echo "Setting up the system clock."
     hwclock --systohc
-    
+
     # Generating locales.
     echo "Generating locales."
     locale-gen &>/dev/null
-    
+
     # Generating a new initramfs.
     echo "Creating a new initramfs."
     mkinitcpio -P &>/dev/null
-    
+
     # Snapper configuration
     echo "Configuring Snapper."
     umount /.snapshots
@@ -406,7 +406,7 @@ arch-chroot /mnt /bin/bash -e <<EOF
     mkdir /.snapshots
     mount -a
     chmod 750 /.snapshots
-    
+
     # Installing GRUB.
     echo "Installing GRUB on /boot."
     grub-install --target=x86_64-efi --efi-directory=/boot/ --bootloader-id=GRUB &>/dev/null
@@ -426,7 +426,7 @@ if [ -n "$username" ]; then
     print "Adding the user $username to the system with root privilege."
     arch-chroot /mnt useradd -m -G wheel -s /bin/bash "$username"
     sed -i '/%wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
-    print "Setting user password for $username." 
+    print "Setting user password for $username."
     echo "$username:$userpass" | arch-chroot /mnt chpasswd
 fi
 

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -424,7 +424,7 @@ echo "root:$rootpass" | arch-chroot /mnt chpasswd
 if [ -n "$username" ]; then
     print "Adding the user $username to the system with root privilege."
     arch-chroot /mnt useradd -m -G wheel -s /bin/bash "$username"
-    sed -i '/%wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
+    sed -i '/^ #%wheel ALL=(ALL) ALL/s/^ #//' /mnt/etc/sudoers
     print "Setting user password for $username."
     echo "$username:$userpass" | arch-chroot /mnt chpasswd
 fi
@@ -456,7 +456,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i '/^#ParallelDownloads/s/=.*/= 10/;/#Color/a ILoveCandy' /mnt/etc/pacman.conf
+sed -i 's/#Color/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -196,7 +196,7 @@ hostname_selector () {
 
 # User chooses the locale (function).
 locale_selector () {
-    read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or "/" to search locales): " locale
+    read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or \"/\" to search locales): " locale
     case $locale in
         '') print "en_US will be used as default locale."
             locale="en_US.UTF-8";;
@@ -213,7 +213,7 @@ locale_selector () {
 
 # User chooses the console keyboard layout (function).
 keyboard_selector () {
-    read -r -p "Please insert the keyboard keymap/layout to use in console (enter empty to use us, or "/" to search keymaps): " kblayout
+    read -r -p "Please insert the keyboard keymap/layout to use in console (enter empty to use us, or \"/\" to search keymaps): " kblayout
     case $kblayout in
         '') print "The us keymap will be used in console by default."
             kblayout="us"
@@ -221,7 +221,7 @@ keyboard_selector () {
         '/') localectl list-keymaps
              clear
              return 1;;
-        *) if ! $(localectl list-keymaps | grep -Fxq $kblayout); then
+        *) if ! localectl list-keymaps | grep -Fxq $kblayout; then
                incEcho "The specified keymap doesn't exist."
                return 1
            fi
@@ -313,8 +313,8 @@ mount $BTRFS /mnt
 # Creating BTRFS subvolumes.
 print "Creating BTRFS subvolumes."
 subvols=(snapshots var_pkgs var_log home root srv)
-for subvol in '' ${subvols[@]}; do
-    btrfs su cr /mnt/@$subvol
+for subvol in '' "${subvols[@]}"; do
+    btrfs su cr /mnt/@"$subvol"
 done
 
 # Mounting the newly created subvolumes.
@@ -323,8 +323,8 @@ print "Mounting the newly created subvolumes."
 mountopts="ssd,noatime,compress-force=zstd:3,discard=async"
 mount -o $mountopts,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
-for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
-mount -o $mountopts,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
+for subvol in "${subvols[@]:2}"; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
+mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/$(sed 's,_,/,g' <<< "$subvol")
 done
 chmod -R 750 /mnt/root
 mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -104,20 +104,20 @@ network_selector () {
 
 # Setting up a password for the LUKS Container (function).
 lukspass_selector () {
-	while true; do
-	read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
-		while [ -z "$password" ]; do
-		echo
-		print "You need to enter a password for the LUKS Container in order to continue."
-		read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
-		[ -n "$password" ] && break
-		done
-	echo
-	read -r -s -p "Password (again): " password2
-	echo
-	[ "$password" = "$password2" ] && break
-	echo "Passwords don't match, try again."
-	done
+    while true; do
+        read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
+        while [ -z "$password" ]; do
+            echo
+            print "You need to enter a password for the LUKS Container in order to continue."
+            read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
+            [ -n "$password" ] && break
+        done
+        echo
+        read -r -s -p "Password (again): " password2
+        echo
+        [ "$password" = "$password2" ] && break
+        echo "Passwords don't match, try again."
+    done
     echo -n "$password" | cryptsetup luksFormat "$CRYPTROOT" -d -
     echo -n "$password" | cryptsetup open "$CRYPTROOT" cryptroot -d -
     BTRFS="/dev/mapper/cryptroot"
@@ -125,38 +125,38 @@ lukspass_selector () {
 
 # Setting up a password for the user account (function).
 userpass_selector () {
-while true; do
-  read -r -s -p "Set a user password for $username: " userpass
-	while [ -z "$userpass" ]; do
-	echo
-	print "You need to enter a password for $username."
-	read -r -s -p "Set a user password for $username: " userpass
-	[ -n "$userpass" ] && break
-	done
-  echo
-  read -r -s -p "Insert password again: " userpass2
-  echo
-  [ "$userpass" = "$userpass2" ] && break
-  echo "Passwords don't match, try again."
-done
+    while true; do
+        read -r -s -p "Set a user password for $username: " userpass
+        while [ -z "$userpass" ]; do
+            echo
+            print "You need to enter a password for $username."
+            read -r -s -p "Set a user password for $username: " userpass
+            [ -n "$userpass" ] && break
+        done
+        echo
+        read -r -s -p "Insert password again: " userpass2
+        echo
+        [ "$userpass" = "$userpass2" ] && break
+        echo "Passwords don't match, try again."
+    done
 }
 
 # Setting up a password for the root account (function).
 rootpass_selector () {
-while true; do
-  read -r -s -p "Set a root password: " rootpass
-	while [ -z "$rootpass" ]; do
-	echo
-	print "You need to enter a root password."
-	read -r -s -p "Set a root password: " rootpass
-	[ -n "$rootpass" ] && break
-	done
-  echo
-  read -r -s -p "Password (again): " rootpass2
-  echo
-  [ "$rootpass" = "$rootpass2" ] && break
-  echo "Passwords don't match, try again."
-done
+    while true; do
+        read -r -s -p "Set a root password: " rootpass
+        while [ -z "$rootpass" ]; do
+            echo
+            print "You need to enter a root password."
+            read -r -s -p "Set a root password: " rootpass
+            [ -n "$rootpass" ] && break
+        done
+        echo
+        read -r -s -p "Password (again): " rootpass2
+        echo
+        [ "$rootpass" = "$rootpass2" ] && break
+        echo "Passwords don't match, try again."
+    done
 }
 
 # Microcode detector (function).

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -194,7 +194,6 @@ locale_selector () {
                locale_selector
            fi
            sed -i "$locale/s/^#//" /etc/locale.gen
-           echo "LANG=$locale" > /mnt/etc/locale.conf
     esac
 }
 
@@ -204,14 +203,14 @@ keyboard_selector () {
     case $kblayout in
         '') print "US keyboard layout will be used by default."
             kblayout="us";;
-        '/') localectl list-keymaps;;
-        *) if ! $(localectl list-keymaps | grep -Fxq $locale); then
+        '/') localectl list-keymaps
+             keyboard_selector;;
+        *) if ! $(localectl list-keymaps | grep -Fxq $kblayout); then
                print "The specified keymap doesn't exist."
                keyboard_selector
            fi
            print "Changing layout to $kblayout."
            loadkeys $kblayout
-           echo "KEYMAP=$kblayout" > /mnt/etc/vconsole.conf;;
     esac
     
 }
@@ -313,6 +312,10 @@ mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots
 mount -o $mountopts,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log
 mount $ESP /mnt/boot/
+
+# Configure selected keyboard layout and locale
+echo "KEYMAP=$kblayout" > /mnt/etc/vconsole.conf
+echo "LANG=$locale" > /mnt/etc/locale.conf
 
 # Pacstrap (setting up a base sytem onto the new root).
 print "Installing the base system (it may take a while)."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -324,7 +324,7 @@ EOF
 # Setting up LUKS2 encryption in grub.
 print "Setting up grub config."
 UUID=$(blkid -s UUID -o value $CRYPTROOT)
-sed -i "s,^GRUB_CMDLINE_LINUX=\"\",GRUB_CMDLINE_LINUX=\"rd.luks.name=$UUID=cryptroot root=$BTRFS\",g" /mnt/etc/default/grub
+sed -i "s,^GRUB_CMDLINE_LINUX=\",&rd.luks.name=$UUID=cryptroot root=$BTRFS\",g" /mnt/etc/default/grub
 
 # Configuring the system.    
 arch-chroot /mnt /bin/bash -e <<EOF
@@ -373,7 +373,7 @@ echo "root:$rootpass" | arch-chroot /mnt chpasswd
 if [ -n "$username" ]; then
     print "Adding the user $username to the system with root privilege."
     arch-chroot /mnt useradd -m -G wheel -s /bin/bash "$username"
-    sed -i 's/# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/' /mnt/etc/sudoers
+    sed -i '%wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
     print "Setting user password for $username." 
     echo "$username:$userpass" | arch-chroot /mnt chpasswd
 fi

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -430,7 +430,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i '/#Color/a ILoveCandy;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
+sed -i '/^#ParallelDownloads/s/=.*/= 10/;/#Color/a ILoveCandy' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -430,7 +430,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i 's/#Color/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
+sed -i '/#Color/a ILoveCandy;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -264,7 +264,7 @@ umount /mnt
 print "Mounting the newly created subvolumes."
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
-for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@var_pkgs and @snapshots) from loop
+for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
 done
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@snapshots $BTRFS /mnt/.snapshots

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -185,10 +185,12 @@ hostname_selector () {
 # Setting up the locale (function).
 locale_selector () {
     read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or type a "/" to search avaliable locales): " locale
-    case $kblayout in
+    case $locale in
         '') print "en_US will be used as default locale."
             locale="en_US.UTF-8";;
-        '/') sed -E '/^# +|^#$/d;s/^#| *$//g;s/ .*/      (Charset:&)/' /etc/locale.gen | less -M;;
+        '/') sed -E '/^# +|^#$/d;s/^#| *$//g;s/ .*/      (Charset:&)/' /etc/locale.gen | less -M
+             clear
+             locale_selector;;
         *) if ! grep -Fxq $locale /etc/locale.gen; then
                print "The specified locale doesn't exist or isn't supported."
                locale_selector
@@ -204,6 +206,7 @@ keyboard_selector () {
         '') print "US keyboard layout will be used by default."
             kblayout="us";;
         '/') localectl list-keymaps
+             clear
              keyboard_selector;;
         *) if ! $(localectl list-keymaps | grep -Fxq $kblayout); then
                print "The specified keymap doesn't exist."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -317,7 +317,7 @@ mount $BTRFS /mnt
 print "Creating BTRFS subvolumes."
 subvols=(snapshots var_pkgs var_log home root srv)
 for subvol in '' ${subvols[@]}; do
-    btrfs su cr /mnt/@$volume
+    btrfs su cr /mnt/@$subvol
 done
 
 # Mounting the newly created subvolumes.

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -326,7 +326,7 @@ mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in "${subvols[@]:2}"; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
 mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/"$(sed 's,_,/,g' <<< "$subvol")"
 done
-chmod -R 750 /mnt/root
+chmod 750 /mnt/root
 mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots
 mount -o $mountopts,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log
@@ -375,7 +375,7 @@ EOF
 # Setting up LUKS2 encryption in grub.
 print "Setting up grub config."
 UUID=$(blkid -s UUID -o value $CRYPTROOT)
-sed -i "s,^GRUB_CMDLINE_LINUX=\",&rd.luks.name=$UUID=cryptroot root=$BTRFS\",g" /mnt/etc/default/grub
+sed -i "\,^GRUB_CMDLINE_LINUX=\"\",s,\",&rd.luks.name=$UUID=cryptroot root=$BTRFS," /mnt/etc/default/grub
 
 # Configuring the system.
 arch-chroot /mnt /bin/bash -e <<EOF

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -424,7 +424,7 @@ echo "root:$rootpass" | arch-chroot /mnt chpasswd
 if [ -n "$username" ]; then
     print "Adding the user $username to the system with root privilege."
     arch-chroot /mnt useradd -m -G wheel -s /bin/bash "$username"
-    sed -i '/^ #%wheel ALL=(ALL) ALL/s/^ #//' /mnt/etc/sudoers
+    sed -i '/^# %wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
     print "Setting user password for $username."
     echo "$username:$userpass" | arch-chroot /mnt chpasswd
 fi

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -5,7 +5,6 @@ clear
 
 # Colors/formatting for echo
   BOLD='\e[1m'
-  UNDERLINE='\e[4m'
   RESET='\e[0m' # Reset text to default appearance
 #   High intensity colors:
     BRED='\e[91m'
@@ -15,7 +14,7 @@ clear
 
 # Pretty print (function).
 print () {
-    echo -e "${BOLD}${BYELLOW}[ ${BGREEN}•${BYELLOW} ] ${UNDERLINE}$1${RESET}"
+    echo -e "${BOLD}${BYELLOW}[ ${BGREEN}•${BYELLOW} ] $1${RESET}"
 }
 # Alert user of bad input (function).
 incEcho () {
@@ -247,7 +246,7 @@ do
 done
 
 # Warn user about deletion of old partition scheme.
-echo -en "${BOLD}${UNDERLINE}${BRED}This will delete the current partition table on $DISK once installation starts. Do you agree [y/N]?:${RESET} "
+echo -en "${BOLD}${BRED}This will delete the current partition table on $DISK once installation starts. Do you agree [y/N]?:${RESET} "
 read -r disk_response
 disk_response=${disk_response,,}
 if ! [[ "$disk_response" =~ ^(yes|y)$ ]]; then

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -456,7 +456,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i 's/#Color/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
+sed -i 's/^#Color$/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -324,7 +324,7 @@ mountopts="ssd,noatime,compress-force=zstd:3,discard=async"
 mount -o $mountopts,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in "${subvols[@]:2}"; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
-mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/$(sed 's,_,/,g' <<< "$subvol")
+mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/"$(sed 's,_,/,g' <<< "$subvol")"
 done
 chmod -R 750 /mnt/root
 mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -120,7 +120,7 @@ network_installer () {
     esac
 }
 
-# Setting up a password for the LUKS Container (function).
+# User enters a password for the LUKS Container (function).
 lukspass_selector () {
     while true; do
         read -r -s -p "Insert password for the LUKS container (you're not going to see the password): " password
@@ -138,7 +138,7 @@ lukspass_selector () {
     done
 }
 
-# Setting up a password for the user account (function).
+# User enters a password for the user account (function).
 userpass_selector () {
     while true; do
         read -r -s -p "Set a user password for $username: " userpass
@@ -156,7 +156,7 @@ userpass_selector () {
     done
 }
 
-# Setting up a password for the root account (function).
+# User enters a password for the root account (function).
 rootpass_selector () {
     while true; do
         read -r -s -p "Set a root password: " rootpass
@@ -186,7 +186,7 @@ microcode_detector () {
     fi
 }
 
-# User chooses the hostname (function).
+# User enters a hostname (function).
 hostname_selector () {
     read -r -p "Please enter the hostname: " hostname
     if [ -z "$hostname" ]; then
@@ -196,9 +196,9 @@ hostname_selector () {
     return 0
 }
 
-# Setting up the locale (function).
+# User chooses the locale (function).
 locale_selector () {
-    read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or type a "/" to search avaliable locales): " locale
+    read -r -p "Please insert the locale you use (format: xx_XX. Enter empty to use en_US, or "/" to search locales): " locale
     case $locale in
         '') print "en_US will be used as default locale."
             locale="en_US.UTF-8";;
@@ -214,11 +214,11 @@ locale_selector () {
     esac
 }
 
-# Setting up the keyboard layout (function).
+# User chooses the console keyboard layout (function).
 keyboard_selector () {
-    read -r -p "Please insert the keyboard layout you use (enter empty to use US keyboard layout, or enter "/" to search avaliable layouts): " kblayout
+    read -r -p "Please insert the keyboard keymap/layout to use in console (enter empty to use us, or "/" to search keymaps): " kblayout
     case $kblayout in
-        '') print "US keyboard layout will be used by default."
+        '') print "The us keymap will be used in console by default."
             kblayout="us"
             return 0;;
         '/') localectl list-keymaps
@@ -228,7 +228,7 @@ keyboard_selector () {
                incEcho "The specified keymap doesn't exist."
                return 1
            fi
-           print "Changing layout to $kblayout."
+           print "Changing console layout to $kblayout."
            loadkeys $kblayout
            return 0
     esac

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -341,7 +341,7 @@ print "Generating a new fstab."
 genfstab -U /mnt >> /mnt/etc/fstab
 
 # Configure selected locale and console keymap
-sed -i "s/^#$locale/$locale/" /mnt/etc/locale.gen
+sed -i "/^#$locale/s/^#//" /mnt/etc/locale.gen
 echo "LANG=$locale" > /mnt/etc/locale.conf
 echo "KEYMAP=$kblayout" > /mnt/etc/vconsole.conf
 
@@ -453,7 +453,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i 's/^#Color$/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
+sed -Ei 's/^#(Color)$/\1\nILoveCandy/;s/^#(ParallelDownloads).*/\1 = 10/' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -263,7 +263,7 @@ done
 umount /mnt
 print "Mounting the newly created subvolumes."
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@ $BTRFS /mnt
-mkdir -p /mnt/{home,root,srv,.snapshots,/var/log,/var/cache/pacman/pkg,boot}
+mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@var_pkgs and @snapshots) from loop
 mount -o ssd,noatime,compress-force=zstd:3,discard=async,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
 done

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -430,7 +430,7 @@ EOF
 
 # Pacman eye-candy features.
 print "Enabling colours, animations, and parallel in pacman."
-sed -i 's/#Color/Color\nILoveCandy/;s/^#ParallelDownloads.*$/ParallelDownloads = 10/' /mnt/etc/pacman.conf
+sed -i 's/#Color/Color\nILoveCandy/;s/^#ParallelDownloads.*/ParallelDownloads = 10/' /mnt/etc/pacman.conf
 
 # Enabling various services.
 print "Enabling Reflector, automatic snapshots, BTRFS scrubbing and systemd-oomd."

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -323,7 +323,7 @@ mountopts="ssd,noatime,compress-force=zstd:3,discard=async"
 mount -o $mountopts,subvol=@ $BTRFS /mnt
 mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in "${subvols[@]:2}"; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
-mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/"$(sed 's,_,/,g' <<< "$subvol")"
+mount -o "$mountopts",subvol=@"$subvol" "$BTRFS" /mnt/"${subvol//_//}"
 done
 chmod 750 /mnt/root
 mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -373,7 +373,7 @@ echo "root:$rootpass" | arch-chroot /mnt chpasswd
 if [ -n "$username" ]; then
     print "Adding the user $username to the system with root privilege."
     arch-chroot /mnt useradd -m -G wheel -s /bin/bash "$username"
-    sed -i '%wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
+    sed -i '/%wheel ALL=(ALL) ALL/s/^# //' /mnt/etc/sudoers
     print "Setting user password for $username." 
     echo "$username:$userpass" | arch-chroot /mnt chpasswd
 fi

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -326,6 +326,7 @@ mkdir -p /mnt/{home,root,srv,.snapshots,var/{log,cache/pacman/pkg},boot}
 for subvol in ${subvols[@]:2}; do # ":2" excludes first two subvols (@snapshots and @var_pkgs) from loop
 mount -o $mountopts,subvol=@$subvol $BTRFS /mnt/$(sed 's,_,/,g' <<< $subvol)
 done
+chmod -R 750 /mnt/root
 mount -o $mountopts,subvol=@snapshots $BTRFS /mnt/.snapshots
 mount -o $mountopts,subvol=@var_pkgs $BTRFS /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log


### PR DESCRIPTION
There's several changes, but the main ones are:

- Change some functions to not format/install until after the user has already answered all pre-install questions, and move `microcode_detector` and `virt_check` later in the script for the same reason
- Ability to search existing locales/keyboard layouts by entering "/" at the prompts
  - Once a locale/layout is actually entered, it's checked against all existing ones to see if it exists, and if not the function is re-ran to pick again
- When installing the locale, don't assume it's UTF-8, and uncomment it from locale.gen instead of appending it
- Move mount options to variables for neatness and ease of modification
- Put subvols in array so they can be created with a loop (and mounted if the subvol name is it's mount dir with / replaced with _ (e.g. @var_log))
- Changed functions with user input to use a [different method](https://unix.stackexchange.com/a/268769) for repeating questions after incorrect input to fix a bug where if incorrect answers are given the function's commands will run multiple times after a correct answer
- Change permissions of /root from 755 to 750 to fix "directory permissions differ" warnings during pacstrap