### PR TITLE
Fixed pacstrap errors

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -356,7 +356,7 @@ microcode_detector
 
 # Pacstrap (setting up a base sytem onto the new root).
 info_print "Installing the base system (it may take a while)."
-pacstrap /mnt base "$kernel" "$microcode" linux-firmware "$kernel"-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector snap-pac zram-generator &>/dev/null
+pacstrap /mnt base "$kernel" "$microcode" linux-firmware "$kernel"-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector snap-pac zram-generator sudo &>/dev/null
 
 # Setting up the hostname.
 echo "$hostname" > /mnt/etc/hostname

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -351,6 +351,9 @@ mount -o "$mountopts",subvol=@var_pkgs "$BTRFS" /mnt/var/cache/pacman/pkg
 chattr +C /mnt/var/log
 mount "$ESP" /mnt/boot/
 
+# Checking the microcode to install.
+microcode_detector
+
 # Pacstrap (setting up a base sytem onto the new root).
 info_print "Installing the base system (it may take a while)."
 pacstrap /mnt base "$kernel" "$microcode" linux-firmware "$kernel"-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector snap-pac zram-generator &>/dev/null
@@ -374,9 +377,6 @@ cat > /mnt/etc/hosts <<EOF
 ::1         localhost
 127.0.1.1   $hostname.localdomain   $hostname
 EOF
-
-# Checking the microcode to install.
-microcode_detector
 
 # Virtualization check.
 virt_check


### PR DESCRIPTION
![easy-arch-fail](https://user-images.githubusercontent.com/20297496/194408334-bd670545-df84-4027-9af5-a884f8cb3790.jpg)

Script was failing on two parts. The microcode_detector was being ran after $microcode var was needed so the majority of packages being installed during the initial pacstrap were not getting installed. This included grub and caused later grub changes to fail (as seen in screenshot. I was also getting errors regarding /mnt/etc/sudoers.d/wheel not existing. This was resolved by installing the sudo package prior.
