### PR TITLE
Revert #bd7de274214a21b378f6b830d730105864f51661

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -359,7 +359,7 @@ microcode_detector
 
 # Pacstrap (setting up a base sytem onto the new root).
 info_print "Installing the base system (it may take a while)."
-pacstrap -K /mnt base "$kernel" "$microcode" linux-firmware "$kernel"-headers sbctl btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector snap-pac zram-generator sudo &>/dev/null
+pacstrap -K /mnt base "$kernel" "$microcode" linux-firmware "$kernel"-headers btrfs-progs grub grub-btrfs rsync efibootmgr snapper reflector snap-pac zram-generator sudo &>/dev/null
 
 # Setting up the hostname.
 echo "$hostname" > /mnt/etc/hostname
@@ -410,10 +410,6 @@ arch-chroot /mnt /bin/bash -e <<EOF
 
     # Generating locales.
     locale-gen &>/dev/null
-
-    # Create SecureBoot keys. 
-    # This isn't strictly necessary, linux-hardened preset expects it and mkinitcpio will fail without it
-    sbctl create-keys
 
     # Generating a new initramfs.
     mkinitcpio -P &>/dev/null


### PR DESCRIPTION
So when I made this PR https://github.com/classy-giraffe/easy-arch/pull/60 I hallucinated a bit. sbctl is not needed.

When I was updating my old script, I did notice that there was an error with sbctl not existing. This only happens when you try to pacstrap both the kernel and sbctl in the same command. sbctl will add a hook to autosign the kernel, but it cannot do it because the user has not created the key.

Since your intention is not to bother with secure boot anyways, there's no need for sbctl.