### PR TITLE
Show more information during disk selection

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -268,7 +268,7 @@ mapfile -t ARR < <(lsblk -dpno NAME,SIZE,MODEL | grep -P "/dev/sd|nvme|vd");
 PS3="Please select the number of the corresponding disk (e.g. 1): "
 select ENTRY in "${ARR[@]}";
 do
-    DISK="$(ARR=($ENTRY);echo ${ARR[0]})"
+    DISK="$($ENTRY | awk '{print $1;}')"
     info_print "Arch Linux will be installed on the following disk: $DISK"
     break
 done

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -9,7 +9,7 @@ clear
 # Cosmetics (colours for text).
 BOLD='\e[1m'
 BRED='\e[91m'
-BBLUE='\e[34m'  
+BBLUE='\e[34m'
 BGREEN='\e[92m'
 BYELLOW='\e[93m'
 RESET='\e[0m'
@@ -62,7 +62,7 @@ kernel_selector () {
     info_print "2) Hardened: A security-focused Linux kernel"
     info_print "3) Longterm: Long-term support (LTS) Linux kernel"
     info_print "4) Zen Kernel: A Linux kernel optimized for desktop usage"
-    input_print "Please select the number of the corresponding kernel (e.g. 1): " 
+    input_print "Please select the number of the corresponding kernel (e.g. 1): "
     read -r kernel_choice
     case $kernel_choice in
         1 ) kernel="linux"
@@ -152,7 +152,7 @@ userpass_selector () {
         return 1
     fi
     echo
-    input_print "Please enter the password again (you're not going to see it): " 
+    input_print "Please enter the password again (you're not going to see it): "
     read -r -s userpass2
     echo
     if [[ "$userpass" != "$userpass2" ]]; then
@@ -173,7 +173,7 @@ rootpass_selector () {
         return 1
     fi
     echo
-    input_print "Please enter the password again (you're not going to see it): " 
+    input_print "Please enter the password again (you're not going to see it): "
     read -r -s rootpass2
     echo
     if [[ "$rootpass" != "$rootpass2" ]]; then
@@ -264,10 +264,11 @@ until keyboard_selector; do : ; done
 
 # Choosing the target for the installation.
 info_print "Available disks for the installation:"
+mapfile -t ARR < <(lsblk -dpno NAME,SIZE,MODEL | grep -P "/dev/sd|nvme|vd");
 PS3="Please select the number of the corresponding disk (e.g. 1): "
-select ENTRY in $(lsblk -dpnoNAME|grep -P "/dev/sd|nvme|vd");
+select ENTRY in "${ARR[@]}";
 do
-    DISK="$ENTRY"
+    DISK="$(ARR=($ENTRY);echo ${ARR[0]})"
     info_print "Arch Linux will be installed on the following disk: $DISK"
     break
 done
@@ -324,7 +325,7 @@ mkfs.fat -F 32 "$ESP" &>/dev/null
 # Creating a LUKS Container for the root partition.
 info_print "Creating LUKS Container for the root partition."
 echo -n "$password" | cryptsetup luksFormat "$CRYPTROOT" -d - &>/dev/null
-echo -n "$password" | cryptsetup open "$CRYPTROOT" cryptroot -d - 
+echo -n "$password" | cryptsetup open "$CRYPTROOT" cryptroot -d -
 BTRFS="/dev/mapper/cryptroot"
 
 # Formatting the LUKS Container as BTRFS.

--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -9,7 +9,7 @@ clear
 # Cosmetics (colours for text).
 BOLD='\e[1m'
 BRED='\e[91m'
-BBLUE='\e[34m'
+BBLUE='\e[34m'  
 BGREEN='\e[92m'
 BYELLOW='\e[93m'
 RESET='\e[0m'
@@ -62,7 +62,7 @@ kernel_selector () {
     info_print "2) Hardened: A security-focused Linux kernel"
     info_print "3) Longterm: Long-term support (LTS) Linux kernel"
     info_print "4) Zen Kernel: A Linux kernel optimized for desktop usage"
-    input_print "Please select the number of the corresponding kernel (e.g. 1): "
+    input_print "Please select the number of the corresponding kernel (e.g. 1): " 
     read -r kernel_choice
     case $kernel_choice in
         1 ) kernel="linux"
@@ -152,7 +152,7 @@ userpass_selector () {
         return 1
     fi
     echo
-    input_print "Please enter the password again (you're not going to see it): "
+    input_print "Please enter the password again (you're not going to see it): " 
     read -r -s userpass2
     echo
     if [[ "$userpass" != "$userpass2" ]]; then
@@ -173,7 +173,7 @@ rootpass_selector () {
         return 1
     fi
     echo
-    input_print "Please enter the password again (you're not going to see it): "
+    input_print "Please enter the password again (you're not going to see it): " 
     read -r -s rootpass2
     echo
     if [[ "$rootpass" != "$rootpass2" ]]; then
@@ -325,7 +325,7 @@ mkfs.fat -F 32 "$ESP" &>/dev/null
 # Creating a LUKS Container for the root partition.
 info_print "Creating LUKS Container for the root partition."
 echo -n "$password" | cryptsetup luksFormat "$CRYPTROOT" -d - &>/dev/null
-echo -n "$password" | cryptsetup open "$CRYPTROOT" cryptroot -d -
+echo -n "$password" | cryptsetup open "$CRYPTROOT" cryptroot -d - 
 BTRFS="/dev/mapper/cryptroot"
 
 # Formatting the LUKS Container as BTRFS.


### PR DESCRIPTION
This proposed change includes the disk size and model information as output by `lsblk` to help users distinguish between devices.

This change uses an array for the `lsblk` output so that `select` uses the array elements as the options rather than each word, and then uses `awk` to extract the first word (the NAME column) from the selected line.

Tested in VirtualBox:

<img width="1240" height="722" alt="screenshot_2025-12-22_10-12-14" src="https://github.com/user-attachments/assets/d5bf27ff-35d1-45ad-abb9-b25f462e166c" />
