### PR TITLE
Fix "Permission denied" during disk selection (#71)

### DIFF
--- a/easy-arch.sh
+++ b/easy-arch.sh
@@ -268,7 +268,7 @@ mapfile -t ARR < <(lsblk -dpno NAME,SIZE,MODEL | grep -P "/dev/sd|nvme|vd");
 PS3="Please select the number of the corresponding disk (e.g. 1): "
 select ENTRY in "${ARR[@]}";
 do
-    DISK="$($ENTRY | awk '{print $1;}')"
+    DISK="$(echo "$ENTRY" | awk '{print $1;}')"
     info_print "Arch Linux will be installed on the following disk: $DISK"
     break
 done


### PR DESCRIPTION
Fixes issue [issue 71](https://github.com/classy-giraffe/easy-arch/issues/71). Substituting the list entry (`ENTRY`) directly in line 271 causes Bash to interpret the disk path at the start as a path to an executable, resulting in the permission denied error. This fix uses `echo` to pipe the list entry into `awk` to prevent this.

Tested in Hyper-V with Arch 2026.07.01 installation media.